### PR TITLE
Support for serializing nested dictionaries as mentioned on SO

### DIFF
--- a/beatbox.py
+++ b/beatbox.py
@@ -403,6 +403,9 @@ class AuthenticatedRequest(SoapEnvelope):
 			s.writeStringElement(_sobjectNs, "type", sObjects['type'])
 			for fn in sObjects.keys():
 				if (fn != 'type'):
+	                            if (isinstance(sObjects[fn],dict)):
+                                        self.writeSObjects(s, sObjects[fn], fn)
+                                    else:
 					s.writeStringElement(_sobjectNs, fn, sObjects[fn])
 			s.endElement()
 	


### PR DESCRIPTION
Small change to writeSObjects to call recursively on nested dicts, possibility of a problem with dicts containing themselves, I was unable to run demo.py as it's throwing a

AttributeError: BeatBoxXmlGenerator instance has no attribute '_write'

under Python 2.7.5
