### PR TITLE
Expected Bytes got String in GzipFile

### DIFF
--- a/beatbox.py
+++ b/beatbox.py
@@ -279,7 +279,7 @@ class BeatBoxXmlGenerator(XMLGenerator):
 # general purpose xml writer, does a bunch of useful stuff above & beyond XmlGenerator
 class XmlWriter:
 	def __init__(self, doGzip):
-		self.__buf = StringIO("")
+		self.__buf = BytesIO(b"")
 		if doGzip:
 			self.__gzip = gzip.GzipFile(mode='wb', fileobj=self.__buf)
 			stm = self.__gzip


### PR DESCRIPTION
gzip through XMLWriter was expecting bytes but instead a string buffer was created. This was throwing an error i(Python 3.5) in gzip when writing the 'magic header' as a byte string. 

