### PR TITLE
Unicode compatible

### DIFF
--- a/beatbox.py
+++ b/beatbox.py
@@ -457,8 +457,7 @@ class SoapEnvelope(object):
             rawResponse = gzip.GzipFile(fileobj=BytesIO(rawResponse)).read()
         if close:
             conn.close()
-        string_response = rawResponse.decode('utf-8') if PY3 else rawResponse
-        tramp = xmltramp.parse(string_response)
+        tramp = xmltramp.parse(raw_response)
         try:
             faultString = str(tramp[_tSoapNS.Body][_tSoapNS.Fault].faultstring)
             faultCode = str(tramp[_tSoapNS.Body][_tSoapNS.Fault].faultcode).split(':')[-1]

--- a/test_beatbox.py
+++ b/test_beatbox.py
@@ -3,7 +3,7 @@ import beatbox
 import datetime
 import gzip
 import xmltramp
-from beatbox_six import BytesIO, PY3
+from beatbox_six import BytesIO
 
 class TestXmlWriter(unittest.TestCase):
 
@@ -84,8 +84,7 @@ class TestSoapWriter(unittest.TestCase):
         xml = w.endDocument()
         # because attributes aren't ordered, we can't do a simple sting assert check here
         # we need to actually parse and verify the xml that way
-        xml_str = xml.decode('utf-8') if PY3 else xml
-        root = xmltramp.parse(xml_str)
+        root = xmltramp.parse(xml)
         hdr = root[0]
         soapNs = xmltramp.Namespace("http://schemas.xmlsoap.org/soap/envelope/")
         xsiNs = xmltramp.Namespace("http://www.w3.org/2001/XMLSchema-instance")

--- a/test_beatbox.py
+++ b/test_beatbox.py
@@ -18,19 +18,19 @@ class TestXmlWriter(unittest.TestCase):
         self.w.endElement()
         self.w.endElement()
         xml = self.w.endDocument()
-        self.assertEqual(b"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<q:root xmlns:q=\"urn:test\"><q:child>text</q:child></q:root>", xml)
+        self.assertEqual(b'<?xml version="1.0" encoding="utf-8"?>\n<q:root xmlns:q="urn:test"><q:child>text</q:child></q:root>', xml)
 
     def test_writeStringElementList(self):
         self.w.writeStringElement("urn:test", "child", ["a","b"])
         self.w.endElement()
         xml = self.w.endDocument()
-        self.assertEqual(b"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<q:root xmlns:q=\"urn:test\"><q:child>a</q:child><q:child>b</q:child></q:root>", xml)
+        self.assertEqual(b'<?xml version="1.0" encoding="utf-8"?>\n<q:root xmlns:q="urn:test"><q:child>a</q:child><q:child>b</q:child></q:root>', xml)
 
     def test_writeStringElementOne(self):
         self.w.writeStringElement("urn:test", "child", "a")
         self.w.endElement()
         xml = self.w.endDocument()
-        self.assertEqual(b"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<q:root xmlns:q=\"urn:test\"><q:child>a</q:child></q:root>", xml)
+        self.assertEqual(b'<?xml version="1.0" encoding="utf-8"?>\n<q:root xmlns:q="urn:test"><q:child>a</q:child></q:root>', xml)
 
     def test_characterTypes(self):
         self.w.writeStringElement("urn:test", "float", 42.42)
@@ -39,11 +39,11 @@ class TestXmlWriter(unittest.TestCase):
         self.w.writeStringElement("urn:test", "dt", datetime.datetime(2016,6,30,21,22,23))
         self.w.endElement()
         xml = self.w.endDocument()
-        self.assertEqual(b"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<q:root xmlns:q=\"urn:test\"><q:float>42.42</q:float>" +
-            b"<q:int>4242</q:int>" +
-            b"<q:date>2016-06-30</q:date>" +
-            b"<q:dt>2016-06-30T21:22:23</q:dt>" +
-            b"</q:root>", xml)
+        self.assertEqual(b'<?xml version="1.0" encoding="utf-8"?>\n<q:root xmlns:q="urn:test"><q:float>42.42</q:float>' +
+            b'<q:int>4242</q:int>' +
+            b'<q:date>2016-06-30</q:date>' +
+            b'<q:dt>2016-06-30T21:22:23</q:dt>' +
+            b'</q:root>', xml)
 
     def test_gzip(self):
         # note this doesn't use self.w as that's not configured to zip
@@ -55,14 +55,14 @@ class TestXmlWriter(unittest.TestCase):
         zipped = w.endDocument()
         gz = gzip.GzipFile(fileobj=BytesIO(zipped))
         xml = gz.read()
-        self.assertEqual(b"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<q:root xmlns:q=\"urn:test\"><q:child>text</q:child></q:root>", xml)
+        self.assertEqual(b'<?xml version="1.0" encoding="utf-8"?>\n<q:root xmlns:q="urn:test"><q:child>text</q:child></q:root>', xml)
 
 
-soapEnvElement = (b"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-    b"<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\""
-    b" xmlns:p=\"urn:partner.soap.sforce.com\""
-    b" xmlns:o=\"urn:sobject.partner.soap.sforce.com\""
-    b" xmlns:x=\"http://www.w3.org/2001/XMLSchema-instance\">")
+soapEnvElement = (b'<?xml version="1.0" encoding="utf-8"?>\n'
+    b'<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"'
+    b' xmlns:p="urn:partner.soap.sforce.com"'
+    b' xmlns:o="urn:sobject.partner.soap.sforce.com"'
+    b' xmlns:x="http://www.w3.org/2001/XMLSchema-instance">')
 
 class TestSoapWriter(unittest.TestCase):
 
@@ -74,8 +74,8 @@ class TestSoapWriter(unittest.TestCase):
         w.writeStringElement("http://schemas.xmlsoap.org/soap/envelope/", "Body", None)
         xml = w.endDocument()
         self.assertEqual(soapEnvElement +
-            b"<s:Body x:nil=\"true\"></s:Body>" +
-            b"</s:Envelope>", xml)
+            b'<s:Body x:nil="true"></s:Body>' +
+            b'</s:Envelope>', xml)
 
     def test_xsiNilWithAtttrs(self):
         w = beatbox.SoapWriter()
@@ -100,11 +100,11 @@ class TestSoapEnvelope(unittest.TestCase):
         e = beatbox.SoapEnvelope("http://localhost", "bob", "Beatbox/0.96")
         env = e.makeEnvelope()
         self.assertEqual(soapEnvElement +
-            b"<s:Header>\n" +
-            b"<p:CallOptions><p:client>Beatbox/0.96</p:client></p:CallOptions>\n" +
-            b"</s:Header><s:Body>\n" +
-            b"<p:bob></p:bob>" +
-            b"</s:Body></s:Envelope>", env)
+            b'<s:Header>\n' +
+            b'<p:CallOptions><p:client>Beatbox/0.96</p:client></p:CallOptions>\n' +
+            b'</s:Header><s:Body>\n' +
+            b'<p:bob></p:bob>' +
+            b'</s:Body></s:Envelope>', env)
 
 def all_tests():
     """Test suite for setup.py that combines all *unit* tests to one suite."""

--- a/test_beatbox.py
+++ b/test_beatbox.py
@@ -20,6 +20,17 @@ class TestXmlWriter(unittest.TestCase):
         xml = self.w.endDocument()
         self.assertEqual(b'<?xml version="1.0" encoding="utf-8"?>\n<q:root xmlns:q="urn:test"><q:child>text</q:child></q:root>', xml)
 
+    def test_mixedUnicode(self):
+        self.w.startElement(u"urn:test", u"child")
+        self.w.characters(u"text A acute \u00c1.")
+        self.w.characters(b"text A acute \xc3\x81.")
+        self.w.endElement()
+        self.w.endElement()
+        xml = self.w.endDocument()
+        self.assertEqual(b'<?xml version="1.0" encoding="utf-8"?>\n<q:root xmlns:q="urn:test"><q:child>'
+                         b'text A acute \xc3\x81.'
+                         b'text A acute \xc3\x81.</q:child></q:root>', xml)
+
     def test_writeStringElementList(self):
         self.w.writeStringElement("urn:test", "child", ["a","b"])
         self.w.endElement()


### PR DESCRIPTION
The `parse` function now accepts both byte string (useful from socket or gzip) or unicode (useful for tests). Tests can be simplified

It is recommended to change double quotes to apostrophes around string literals if it helps to prevent unnecessary backslashes inside, because it improves readability.
Double quotes are usually better for English text because it frequently contains apostrophes.

Test that the input can be byte string or unicode and the output is the same.
