### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Beatbox is released under the GPL v2.
 
 Beatbox requires Python 2.7.9 or later or Python 3.4 or later. Thanks [hynekcer](https://github.com/hynekcer) for the Python 3 support!
 
+## Installation (Python 3)
+
+The beatbox3 PyPI is stale and not Python 3 compatible (refer to issue #46). 
+
+To ensure that you are using the latest python3 compatible version please install using pip syntax:
+
+#### Command line:
+`pip install -e git+https://github.com/superfell/Beatbox@master#egg=beatbox3`
+
+#### In requirements.txt:
+`-e git+https://github.com/superfell/Beatbox@master#egg=beatbox3`
 
 ## About TLS 1.2 Support
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The beatbox3 PyPI is stale and not Python 3 compatible (refer to issue #46).
 To ensure that you are using the latest python3 compatible version please install using pip syntax:
 
 #### Command line:
-`pip install -e git+https://github.com/superfell/Beatbox@master#egg=beatbox3`
+`pip install -e git+https://github.com/superfell/Beatbox@master#egg=beatbox`
 
 #### In requirements.txt:
-`-e git+https://github.com/superfell/Beatbox@master#egg=beatbox3`
+`-e git+https://github.com/superfell/Beatbox@master#egg=beatbox`
 
 ## About TLS 1.2 Support
 


### PR DESCRIPTION
The beatbox3 PyPI is stale (version 0.96.1) which is incompatible with python3 (see issue #46, regarding sending a StringIO object to gzip)
This updates the readme to reflect that fact and adds installation instructions to save anyone using python 3 the headache of debugging this issue.

The reasoning for this is that the beatbox3 PyPI points to this [beatbox site](http://www.pocketsoap.com/beatbox/) which points to this repo, and (although updated) it's not the version installed by PyPI.

I've read though #43 and know that beatbox needs a new maintainer, and I'm trying my hardest to find the time as I'm sure many others are, but until then, this may help someone out.